### PR TITLE
remove doublewhitespace from LADY CAPULET in r&J

### DIFF
--- a/texts/moby/romeo_and_juliet_moby.xml
+++ b/texts/moby/romeo_and_juliet_moby.xml
@@ -5454,7 +5454,7 @@ Wives, and others</STAGEDIR>
 </SCENE>
 
 <SCENE><TITLE>SCENE II.  Hall in Capulet's house.</TITLE>
-<STAGEDIR>Enter CAPULET, LADY  CAPULET, Nurse, and two
+<STAGEDIR>Enter CAPULET, LADY CAPULET, Nurse, and two
 Servingmen</STAGEDIR>
 
 <SPEECH>
@@ -5567,7 +5567,7 @@ Servingmen</STAGEDIR>
 <STAGEDIR>Exeunt JULIET and Nurse</STAGEDIR>
 
 <SPEECH>
-<SPEAKER>LADY  CAPULET</SPEAKER>
+<SPEAKER>LADY CAPULET</SPEAKER>
 <LINE>We shall be short in our provision:</LINE>
 <LINE>'Tis now near night.</LINE>
 </SPEECH>


### PR DESCRIPTION
I am building a shakespeare-api and in the process of normalizing names, ran into a typo.
